### PR TITLE
Testing demonstration: Without the openapi lock on validator access

### DIFF
--- a/.github/workflows/zulip-ci.yml
+++ b/.github/workflows/zulip-ci.yml
@@ -130,7 +130,7 @@ jobs:
       - name: Run backend tests
         run: |
           source tools/ci/activate-venv
-          ./tools/test-backend --coverage --xml-report --no-html-report --include-webhooks --no-cov-cleanup --ban-console-output
+          ./tools/test-backend zerver.transaction_tests
 
       - name: Run mypy
         run: |

--- a/tools/linter_lib/custom_check.py
+++ b/tools/linter_lib/custom_check.py
@@ -223,7 +223,7 @@ python_rules = RuleList(
     rules=[
         {
             "pattern": "subject|SUBJECT",
-            "exclude_pattern": "subject to the|email|outbox|account deactivation",
+            "exclude_pattern": "subject to the|email|outbox|account deactivation|is subject to",
             "description": "avoid subject as a var",
             "good_lines": ["topic_name"],
             "bad_lines": ['subject="foo"', " MAX_SUBJECT_LEN"],

--- a/tools/test-backend
+++ b/tools/test-backend
@@ -254,6 +254,11 @@ def main() -> None:
         help=("Include webhook tests.  By default, they are skipped for performance."),
     )
     parser.add_argument(
+        "--include-transaction-tests",
+        action="store_true",
+        help=("Include transaction tests.  By default, they are skipped for performance."),
+    )
+    parser.add_argument(
         "--generate-stripe-fixtures",
         action="store_true",
         help=("Generate Stripe test fixtures by making requests to Stripe test network"),
@@ -271,6 +276,7 @@ def main() -> None:
 
     args = options.args
     include_webhooks = options.coverage or options.include_webhooks
+    include_transaction_tests = options.coverage or options.include_transaction_tests
 
     if options.processes is not None and options.processes < 1:
         raise argparse.ArgumentTypeError("option processes: Only positive integers are allowed.")
@@ -349,6 +355,9 @@ def main() -> None:
 
     if full_suite and include_webhooks:
         suites.append("zerver.webhooks")
+
+    if full_suite and include_transaction_tests:
+        suites.append("zerver.transaction_tests")
 
     if options.generate_stripe_fixtures:
         if full_suite:

--- a/zerver/actions/user_groups.py
+++ b/zerver/actions/user_groups.py
@@ -8,7 +8,6 @@ from django.utils.translation import gettext as _
 
 from zerver.lib.exceptions import JsonableError
 from zerver.lib.user_groups import (
-    access_user_group_by_id,
     get_role_based_system_groups_dict,
     set_defaults_for_group_settings,
 )
@@ -269,8 +268,8 @@ def do_send_delete_user_group_event(realm: Realm, user_group_id: int, realm_id: 
     send_event(realm, event, active_user_ids(realm_id))
 
 
-def check_delete_user_group(user_group_id: int, *, acting_user: UserProfile) -> None:
-    user_group = access_user_group_by_id(user_group_id, acting_user, for_read=False)
+def check_delete_user_group(user_group: UserGroup, *, acting_user: UserProfile) -> None:
+    user_group_id = user_group.id
     user_group.delete()
     do_send_delete_user_group_event(acting_user.realm, user_group_id, acting_user.realm.id)
 

--- a/zerver/actions/user_groups.py
+++ b/zerver/actions/user_groups.py
@@ -272,7 +272,7 @@ def do_send_delete_user_group_event(realm: Realm, user_group_id: int, realm_id: 
 def check_delete_user_group(
     user_group_id: int, user_profile: UserProfile, *, acting_user: Optional[UserProfile]
 ) -> None:
-    user_group = access_user_group_by_id(user_group_id, user_profile)
+    user_group = access_user_group_by_id(user_group_id, user_profile, for_read=False)
     user_group.delete()
     do_send_delete_user_group_event(user_profile.realm, user_group_id, user_profile.realm.id)
 

--- a/zerver/actions/user_groups.py
+++ b/zerver/actions/user_groups.py
@@ -269,12 +269,10 @@ def do_send_delete_user_group_event(realm: Realm, user_group_id: int, realm_id: 
     send_event(realm, event, active_user_ids(realm_id))
 
 
-def check_delete_user_group(
-    user_group_id: int, user_profile: UserProfile, *, acting_user: Optional[UserProfile]
-) -> None:
-    user_group = access_user_group_by_id(user_group_id, user_profile, for_read=False)
+def check_delete_user_group(user_group_id: int, *, acting_user: UserProfile) -> None:
+    user_group = access_user_group_by_id(user_group_id, acting_user, for_read=False)
     user_group.delete()
-    do_send_delete_user_group_event(user_profile.realm, user_group_id, user_profile.realm.id)
+    do_send_delete_user_group_event(acting_user.realm, user_group_id, acting_user.realm.id)
 
 
 def do_change_user_group_permission_setting(

--- a/zerver/lib/test_classes.py
+++ b/zerver/lib/test_classes.py
@@ -36,7 +36,7 @@ from django.db.migrations.executor import MigrationExecutor
 from django.db.migrations.state import StateApps
 from django.db.utils import IntegrityError
 from django.http import HttpRequest, HttpResponse
-from django.test import TestCase
+from django.test import SimpleTestCase, TestCase, TransactionTestCase
 from django.test.client import BOUNDARY, MULTIPART_CONTENT, encode_multipart
 from django.test.testcases import SerializeMixin
 from django.urls import resolve
@@ -138,7 +138,7 @@ class UploadSerializeMixin(SerializeMixin):
         super().setUpClass()
 
 
-class ZulipTestCase(TestCase):
+class ZulipTestCaseMixin(SimpleTestCase):
     # Ensure that the test system just shows us diffs
     maxDiff: Optional[int] = None
 
@@ -1685,30 +1685,6 @@ Output:
             realm, licenses, licenses_at_next_renewal, CustomerPlan.MONTHLY
         )
 
-    @contextmanager
-    def capture_send_event_calls(
-        self, expected_num_events: int
-    ) -> Iterator[List[Mapping[str, Any]]]:
-        lst: List[Mapping[str, Any]] = []
-
-        # process_notification takes a single parameter called 'notice'.
-        # lst.append takes a single argument called 'object'.
-        # Some code might call process_notification using keyword arguments,
-        # so mypy doesn't allow assigning lst.append to process_notification
-        # So explicitly change parameter name to 'notice' to work around this problem
-        with mock.patch(
-            "zerver.tornado.event_queue.process_notification", lambda notice: lst.append(notice)
-        ):
-            # Some `send_event` calls need to be executed only after the current transaction
-            # commits (using `on_commit` hooks). Because the transaction in Django tests never
-            # commits (rather, gets rolled back after the test completes), such events would
-            # never be sent in tests, and we would be unable to verify them. Hence, we use
-            # this helper to make sure the `send_event` calls actually run.
-            with self.captureOnCommitCallbacks(execute=True):
-                yield lst
-
-        self.assert_length(lst, expected_num_events)
-
     def create_user_notifications_data_object(
         self, *, user_id: int, **kwargs: Any
     ) -> UserMessageNotificationsData:
@@ -1819,6 +1795,53 @@ Output:
             # Prevent from using the old user object
             user.refresh_from_db()
             self.assertEqual(user.long_term_idle, expected)
+
+
+class ZulipTestCase(ZulipTestCaseMixin, TestCase):
+    @contextmanager
+    def capture_send_event_calls(
+        self, expected_num_events: int
+    ) -> Iterator[List[Mapping[str, Any]]]:
+        lst: List[Mapping[str, Any]] = []
+
+        # process_notification takes a single parameter called 'notice'.
+        # lst.append takes a single argument called 'object'.
+        # Some code might call process_notification using keyword arguments,
+        # so mypy doesn't allow assigning lst.append to process_notification
+        # So explicitly change parameter name to 'notice' to work around this problem
+        with mock.patch(
+            "zerver.tornado.event_queue.process_notification", lambda notice: lst.append(notice)
+        ):
+            # Some `send_event` calls need to be executed only after the current transaction
+            # commits (using `on_commit` hooks). Because the transaction in Django tests never
+            # commits (rather, gets rolled back after the test completes), such events would
+            # never be sent in tests, and we would be unable to verify them. Hence, we use
+            # this helper to make sure the `send_event` calls actually run.
+            with self.captureOnCommitCallbacks(execute=True):
+                yield lst
+
+        self.assert_length(lst, expected_num_events)
+
+
+class ZulipTransactionTestCase(ZulipTestCaseMixin, TransactionTestCase):
+    """This is only intended for testing transaction related behaviors, such as locking
+    with select_for_update or transaction.atomic(durable=True).
+
+    Unlike ZulipTestCase, ZulipTransactionTestCase has the following traits:
+    1. Does not offer isolation between tests by wrapping them inside an atomic transaction.
+    2. Changes are committed to the current worker's test database, so side effects carry on.
+
+    It is very important to ensure that all ZulipTransactionTestCase are written hygienic.
+    There should be no significant side effects on the database that cause other test cases to fail.
+
+    ZulipTestCase should cover the vast majority of use cases. ZulipTransactionTestCase must
+    be used sparsely because it is generally more expensive.
+    """
+
+    def _fixture_teardown(self) -> None:
+        # We override the default _fixture_teardown method defined on TransactionTestCase,
+        # so that the test database does not get flushed for each test.
+        pass  # nocoverage # TODO: The user group race conditions test case will make use of this.
 
 
 class WebhookTestCase(ZulipTestCase):

--- a/zerver/lib/test_classes.py
+++ b/zerver/lib/test_classes.py
@@ -270,7 +270,8 @@ Output:
         extensive test coverage of corner cases in the API to ensure that we've properly
         documented those corner cases.
         """
-        if not url.startswith(("/json", "/api/v1")):
+        # Edited only for reproducing the error
+        if not url.startswith(("/json", "/api/v1", "/testing/user_groups")):
             return
         try:
             content = orjson.loads(result.content)

--- a/zerver/lib/test_helpers.py
+++ b/zerver/lib/test_helpers.py
@@ -517,6 +517,8 @@ def write_instrumentation_reports(full_suite: bool, include_webhooks: bool) -> N
             "static/(?P<path>.+)",
             "flush_caches",
             "external_content/(?P<digest>[^/]+)/(?P<received_url>[^/]+)",
+            # Such endpoints are only used in certain test cases that can be skipped
+            "testing/(?P<path>.+)",
             # These are SCIM2 urls overridden from django-scim2 to return Not Implemented.
             # We actually test them, but it's not being detected as a tested pattern,
             # possibly due to the use of re_path. TODO: Investigate and get them

--- a/zerver/lib/user_groups.py
+++ b/zerver/lib/user_groups.py
@@ -218,14 +218,14 @@ def get_subgroup_ids(user_group: UserGroup, *, direct_subgroup_only: bool = Fals
     return list(subgroup_ids)
 
 
-def get_recursive_subgroups_for_groups(user_group_ids: List[int]) -> List[int]:
+def get_recursive_subgroups_for_groups(user_group_ids: List[int]) -> QuerySet[UserGroup]:
     cte = With.recursive(
         lambda cte: UserGroup.objects.filter(id__in=user_group_ids)
         .values(group_id=F("id"))
         .union(cte.join(UserGroup, direct_supergroups=cte.col.group_id).values(group_id=F("id")))
     )
     recursive_subgroups = cte.join(UserGroup, id=cte.col.group_id).with_cte(cte)
-    return list(recursive_subgroups.values_list("id", flat=True))
+    return recursive_subgroups
 
 
 def get_role_based_system_groups_dict(realm: Realm) -> Dict[str, UserGroup]:

--- a/zerver/lib/user_groups.py
+++ b/zerver/lib/user_groups.py
@@ -1,4 +1,6 @@
-from typing import Dict, Iterable, List, Mapping, Sequence, TypedDict
+from contextlib import contextmanager
+from dataclasses import dataclass
+from typing import Collection, Dict, Iterable, Iterator, List, Mapping, TypedDict
 
 from django.db import transaction
 from django.db.models import F, QuerySet
@@ -20,11 +22,31 @@ class UserGroupDict(TypedDict):
     can_mention_group_id: int
 
 
+@dataclass
+class LockedUserGroupContext:
+    """User groups in this dataclass are guaranteeed to be locked until the
+    end of the current transaction.
+
+    supergroup is the user group to have subgroups added or removed;
+    direct_subgroups are user groups that are recursively queried for subgroups;
+    recursive_subgroups include direct_subgroups and their descendants.
+    """
+
+    supergroup: UserGroup
+    direct_subgroups: List[UserGroup]
+    recursive_subgroups: List[UserGroup]
+
+
 def access_user_group_by_id(
     user_group_id: int, user_profile: UserProfile, *, for_read: bool
 ) -> UserGroup:
     try:
-        user_group = UserGroup.objects.get(id=user_group_id, realm=user_profile.realm)
+        if for_read:
+            user_group = UserGroup.objects.get(id=user_group_id, realm=user_profile.realm)
+        else:
+            user_group = UserGroup.objects.select_for_update().get(
+                id=user_group_id, realm=user_profile.realm
+            )
     except UserGroup.DoesNotExist:
         raise JsonableError(_("Invalid user group"))
     if for_read and not user_profile.is_guest:
@@ -46,17 +68,57 @@ def access_user_group_by_id(
     return user_group
 
 
-def access_user_groups_as_potential_subgroups(
-    user_group_ids: Sequence[int], acting_user: UserProfile
-) -> List[UserGroup]:
-    user_groups = UserGroup.objects.filter(id__in=user_group_ids, realm=acting_user.realm)
+@contextmanager
+def lock_subgroups_with_respect_to_supergroup(
+    potential_subgroup_ids: Collection[int], potential_supergroup_id: int, acting_user: UserProfile
+) -> Iterator[LockedUserGroupContext]:
+    """This locks the user groups with the given potential_subgroup_ids, as well as their indirect subgroups,
+    followed by the potential supergroup. It ensures that we lock the user groups in a consistent order
+    topologically to avoid unnecessary deadlocks on non-conflicting queries.
 
-    valid_group_ids = [group.id for group in user_groups]
-    invalid_group_ids = [group_id for group_id in user_group_ids if group_id not in valid_group_ids]
-    if invalid_group_ids:
-        raise JsonableError(_("Invalid user group ID: {}").format(invalid_group_ids[0]))
+    Regardless of whether the user groups returned are used, always call this helper before making
+    changes to subgroup memberships. This avoids introducing cycles among user groups when there is a
+    race condition in which one of these subgroups become an ancestor of the parent user group in
+    another transaction.
 
-    return list(user_groups)
+    Note that it only does the access_user_group_by_id permission check on the potential supergroup, not
+    the potential subgroups and their recursive subgroups. However, the permission model for accessing subgroups
+    is reserved for changes.
+    """
+    with transaction.atomic():
+        # Calling list with the QuerySet forces its evaluation putting a lock on the queried rows.
+        recursive_subgroups = list(
+            get_recursive_subgroups_for_groups(potential_subgroup_ids).select_for_update(
+                nowait=True
+            )
+        )
+        # TODO: This select_for_update query is subject to deadlocking, and better error handling is needed.
+        # We may use select_for_update(nowait=True) and release the locks held by ending the transaction with a JsonableError
+        # by handling the DatabaseError. But at the current scale of concurrent requests, we rely on Postgres's deadlock
+        # detection when it occurs.
+        potential_supergroup = access_user_group_by_id(
+            potential_supergroup_id, acting_user, for_read=False
+        )
+        # We avoid making a separate query for user_group_ids because the recursive query already returns those user groups.
+        potential_subgroups = [
+            user_group
+            for user_group in recursive_subgroups
+            if user_group.id in potential_subgroup_ids
+        ]
+
+        # We expect that the passed user_group_ids each corresponds to an existing user group.
+        group_ids_found = [group.id for group in potential_subgroups]
+        group_ids_not_found = [
+            group_id for group_id in potential_subgroup_ids if group_id not in group_ids_found
+        ]
+        if group_ids_not_found:
+            raise JsonableError(_("Invalid user group ID: {}").format(group_ids_not_found[0]))
+
+        yield LockedUserGroupContext(
+            direct_subgroups=potential_subgroups,
+            recursive_subgroups=recursive_subgroups,
+            supergroup=potential_supergroup,
+        )
 
 
 def access_user_group_for_setting(
@@ -218,7 +280,7 @@ def get_subgroup_ids(user_group: UserGroup, *, direct_subgroup_only: bool = Fals
     return list(subgroup_ids)
 
 
-def get_recursive_subgroups_for_groups(user_group_ids: List[int]) -> QuerySet[UserGroup]:
+def get_recursive_subgroups_for_groups(user_group_ids: Iterable[int]) -> QuerySet[UserGroup]:
     cte = With.recursive(
         lambda cte: UserGroup.objects.filter(id__in=user_group_ids)
         .values(group_id=F("id"))

--- a/zerver/lib/user_groups.py
+++ b/zerver/lib/user_groups.py
@@ -25,24 +25,24 @@ def access_user_group_by_id(
 ) -> UserGroup:
     try:
         user_group = UserGroup.objects.get(id=user_group_id, realm=user_profile.realm)
-        if for_read and not user_profile.is_guest:
-            # Everyone is allowed to read a user group and check who
-            # are its members. Guests should be unable to reach this
-            # code path, since they can't access user groups API
-            # endpoints, but we check for guests here for defense in
-            # depth.
-            return user_group
-        if user_group.is_system_group:
-            raise JsonableError(_("Insufficient permission"))
-        group_member_ids = get_user_group_direct_member_ids(user_group)
-        if (
-            not user_profile.is_realm_admin
-            and not user_profile.is_moderator
-            and user_profile.id not in group_member_ids
-        ):
-            raise JsonableError(_("Insufficient permission"))
     except UserGroup.DoesNotExist:
         raise JsonableError(_("Invalid user group"))
+    if for_read and not user_profile.is_guest:
+        # Everyone is allowed to read a user group and check who
+        # are its members. Guests should be unable to reach this
+        # code path, since they can't access user groups API
+        # endpoints, but we check for guests here for defense in
+        # depth.
+        return user_group
+    if user_group.is_system_group:
+        raise JsonableError(_("Insufficient permission"))
+    group_member_ids = get_user_group_direct_member_ids(user_group)
+    if (
+        not user_profile.is_realm_admin
+        and not user_profile.is_moderator
+        and user_profile.id not in group_member_ids
+    ):
+        raise JsonableError(_("Insufficient permission"))
     return user_group
 
 

--- a/zerver/lib/user_groups.py
+++ b/zerver/lib/user_groups.py
@@ -21,7 +21,7 @@ class UserGroupDict(TypedDict):
 
 
 def access_user_group_by_id(
-    user_group_id: int, user_profile: UserProfile, *, for_read: bool = False
+    user_group_id: int, user_profile: UserProfile, *, for_read: bool
 ) -> UserGroup:
     try:
         user_group = UserGroup.objects.get(id=user_group_id, realm=user_profile.realm)

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -1441,7 +1441,7 @@ class NormalActionsTest(BaseAction):
         check_user_group_remove_subgroups("events[0]", events[0])
 
         # Test remove event
-        events = self.verify_action(lambda: check_delete_user_group(backend.id, acting_user=othello))
+        events = self.verify_action(lambda: check_delete_user_group(backend, acting_user=othello))
         check_user_group_remove("events[0]", events[0])
 
     def test_default_stream_groups_events(self) -> None:

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -1441,9 +1441,7 @@ class NormalActionsTest(BaseAction):
         check_user_group_remove_subgroups("events[0]", events[0])
 
         # Test remove event
-        events = self.verify_action(
-            lambda: check_delete_user_group(backend.id, othello, acting_user=None)
-        )
+        events = self.verify_action(lambda: check_delete_user_group(backend.id, acting_user=othello))
         check_user_group_remove("events[0]", events[0])
 
     def test_default_stream_groups_events(self) -> None:

--- a/zerver/tests/test_user_groups.py
+++ b/zerver/tests/test_user_groups.py
@@ -10,7 +10,7 @@ from zerver.actions.user_groups import check_add_user_group, promote_new_full_me
 from zerver.actions.users import do_deactivate_user
 from zerver.lib.mention import silent_mention_syntax_for_user
 from zerver.lib.streams import ensure_stream
-from zerver.lib.test_classes import ZulipTestCase
+from zerver.lib.test_classes import ZulipTestCase, ZulipTestCaseMixin
 from zerver.lib.test_helpers import most_recent_usermessage
 from zerver.lib.user_groups import (
     get_direct_user_groups,
@@ -32,7 +32,7 @@ from zerver.models import (
 )
 
 
-class UserGroupTestCase(ZulipTestCase):
+class UserGroupTestMixin(ZulipTestCaseMixin):
     def assert_user_membership(self, user_group: UserGroup, members: Iterable[UserProfile]) -> None:
         user_ids = get_user_group_member_ids(user_group, direct_member_only=True)
         self.assertSetEqual(set(user_ids), {member.id for member in members})
@@ -49,6 +49,8 @@ class UserGroupTestCase(ZulipTestCase):
         members = [self.example_user("othello")]
         return check_add_user_group(realm, group_name, members, acting_user=None)
 
+
+class UserGroupTestCase(UserGroupTestMixin, ZulipTestCase):
     def test_user_groups_in_realm_serialized(self) -> None:
         realm = get_realm("zulip")
         user_group = UserGroup.objects.filter(realm=realm).first()

--- a/zerver/transaction_tests/test_user_groups.py
+++ b/zerver/transaction_tests/test_user_groups.py
@@ -1,0 +1,101 @@
+import threading
+from typing import TYPE_CHECKING, List, Optional
+
+from django.db import connections
+from django.utils.timezone import now as timezon_now
+
+from zerver.actions.user_groups import add_subgroups_to_user_group
+from zerver.lib.test_classes import ZulipTransactionTestCase
+from zerver.models import UserGroup
+from zerver.tests.test_user_groups import UserGroupTestMixin
+from zerver.views.development import user_groups as user_group_view
+
+if TYPE_CHECKING:
+    from django.test.client import _MonkeyPatchedWSGIResponse as TestHttpResponse
+
+
+class UserGroupRaceConditionTestCase(UserGroupTestMixin, ZulipTransactionTestCase):
+    def create_user_group_chain(self) -> List[UserGroup]:
+        """Build a user groups forming a chain through group-group memberships
+        returning a list where each group is the supergroup of its subsequent group.
+        """
+        groups = [self.create_user_group_for_test(f"chain #{timezon_now()}") for _ in range(3)]
+        prev_group = groups[0]
+        for group in groups[1:]:
+            add_subgroups_to_user_group(prev_group, [group], acting_user=None)
+            prev_group = group
+        return groups
+
+    def test_lock_subgroups_with_respect_to_supergroup(self) -> None:
+        self.example_user("iago")
+        self.login("iago")
+        test_case = self
+
+        class RacingThread(threading.Thread):
+            def __init__(self, supergroup_id: int, subgroup_id: int) -> None:
+                threading.Thread.__init__(self)
+                self.response: Optional["TestHttpResponse"] = None
+                self.supergroup_id = supergroup_id
+                self.subgroup_id = subgroup_id
+
+            def run(self) -> None:
+                try:
+                    self.response = test_case.client_post(
+                        url=f"/testing/user_groups/{self.supergroup_id}/subgroups",
+                        info={"add": f"{[self.subgroup_id]}"},
+                    )
+                finally:
+                    # Close all thread-local database connections
+                    connections.close_all()
+
+        def assert_exactly_one_thread_fails(
+            t1: RacingThread,
+            t2: RacingThread,
+            *,
+            error_messsage: str,
+            barrier: Optional[threading.Barrier] = None,
+        ) -> None:
+            help_msg = """We access the test endpoint that wraps around the real subgroup update endpoint
+by sychronizing them after the acquisition of the first lock in the critical region.
+Though unlikely, this test might fail as we have no control over the scheduler when the barrier timeouts.
+""".strip()
+
+            user_group_view.set_sync_after_first_lock(barrier)
+            t1.start()
+            t2.start()
+
+            succeeded = 0
+            for t in [t1, t2]:
+                t.join()
+                response = t.response
+                if response is not None and response.status_code == 200:
+                    succeeded += 1
+                    continue
+
+                assert response is not None
+                self.assert_json_error(response, error_messsage)
+            # Race condition resolution should only allow one thread to succeed
+            self.assertEqual(succeeded, 1, f"Exactly one thread should succeed.\n{help_msg}")
+
+        foo_chain = self.create_user_group_chain()
+        bar_chain = self.create_user_group_chain()
+        # These two threads are conflicting because a cycle would be form if both of them succeed.
+        # Meanwhile, there is a deadlock because we use a Barrier to synchronize both threads to acquire
+        # a lock on one chain of user groups before trying to acquire a lock on the other chain, respectively.
+        assert_exactly_one_thread_fails(
+            RacingThread(supergroup_id=bar_chain[-1].id, subgroup_id=foo_chain[0].id),
+            RacingThread(supergroup_id=foo_chain[0].id, subgroup_id=bar_chain[-1].id),
+            error_messsage="Deadlock detected",
+            barrier=threading.Barrier(2, timeout=3),
+        )
+
+        foo_chain = self.create_user_group_chain()
+        bar_chain = self.create_user_group_chain()
+        # Both threads will attempt to grab a lock on overlapping rows when they first do the recursive query for subgroups.
+        # In this case, we expect that one of the threads fails due to nowait=True for the .select_for_update() call.
+        assert_exactly_one_thread_fails(
+            RacingThread(supergroup_id=bar_chain[-1].id, subgroup_id=foo_chain[0].id),
+            RacingThread(supergroup_id=bar_chain[-1].id, subgroup_id=foo_chain[1].id),
+            error_messsage="Busy lock detected",
+            barrier=threading.Barrier(1, timeout=3),
+        )

--- a/zerver/views/development/user_groups.py
+++ b/zerver/views/development/user_groups.py
@@ -1,0 +1,55 @@
+import threading
+from typing import Any, Optional
+from unittest import mock
+
+from django.db import OperationalError, transaction
+from django.http import HttpRequest, HttpResponse
+
+from zerver.lib.exceptions import JsonableError
+from zerver.lib.request import REQ, has_request_variables
+from zerver.lib.response import json_success
+from zerver.lib.user_groups import access_user_group_by_id
+from zerver.lib.validator import check_int
+from zerver.models import UserGroup, UserProfile
+from zerver.views.user_groups import update_subgroups_of_user_group
+
+BARRIER: Optional[threading.Barrier] = None
+
+
+def set_sync_after_first_lock(barrier: Optional[threading.Barrier]) -> None:
+    global BARRIER
+    BARRIER = barrier
+
+
+@has_request_variables
+def dev_update_subgroups(
+    request: HttpRequest,
+    user_profile: UserProfile,
+    user_group_id: int = REQ(json_validator=check_int, path_only=True),
+) -> HttpResponse:
+    try:
+        with transaction.atomic():
+            with mock.patch("zerver.lib.user_groups.access_user_group_by_id") as m:
+
+                def _delayed_locking(*args: Any, **kwargs: Any) -> UserGroup:
+                    if BARRIER:
+                        BARRIER.wait()
+                    return access_user_group_by_id(*args, **kwargs)
+
+                m.side_effect = _delayed_locking
+                update_subgroups_of_user_group(request, user_profile, user_group_id=user_group_id)
+    except OperationalError as err:
+        msg = str(err)
+        if "deadlock detected" in msg:
+            raise JsonableError("Deadlock detected")
+        else:
+            assert "could not obtain lock" in msg
+            raise JsonableError("Busy lock detected")
+    except (
+        threading.BrokenBarrierError
+    ):  # nocoverage # This is only possible when timeout happens or there is a programming error
+        raise JsonableError(
+            "Broken barrier. The tester should make sure that the exact number of parties have waited on the barrier set by the previous immediate set_sync_after_first_lock call"
+        )
+
+    return json_success(request)

--- a/zerver/views/user_groups.py
+++ b/zerver/views/user_groups.py
@@ -144,7 +144,7 @@ def delete_user_group(
     user_profile: UserProfile,
     user_group_id: int = REQ(json_validator=check_int, path_only=True),
 ) -> HttpResponse:
-    check_delete_user_group(user_group_id, user_profile, acting_user=user_profile)
+    check_delete_user_group(user_group_id, acting_user=user_profile)
     return json_success(request)
 
 

--- a/zerver/views/user_groups.py
+++ b/zerver/views/user_groups.py
@@ -1,6 +1,7 @@
 from typing import List, Optional, Sequence
 
 from django.conf import settings
+from django.db import transaction
 from django.http import HttpRequest, HttpResponse
 from django.utils.translation import gettext as _
 from django.utils.translation import override as override_language
@@ -25,13 +26,12 @@ from zerver.lib.response import json_success
 from zerver.lib.user_groups import (
     access_user_group_by_id,
     access_user_group_for_setting,
-    access_user_groups_as_potential_subgroups,
     get_direct_memberships_of_users,
-    get_recursive_subgroups_for_groups,
     get_subgroup_ids,
     get_user_group_direct_member_ids,
     get_user_group_member_ids,
     is_user_in_group,
+    lock_subgroups_with_respect_to_supergroup,
     user_groups_in_realm_serialized,
 )
 from zerver.lib.users import access_user_by_id, user_ids_to_users
@@ -91,6 +91,7 @@ def get_user_group(request: HttpRequest, user_profile: UserProfile) -> HttpRespo
     return json_success(request, data={"user_groups": user_groups})
 
 
+@transaction.atomic
 @require_user_group_edit_permission
 @has_request_variables
 def edit_user_group(
@@ -144,7 +145,11 @@ def delete_user_group(
     user_profile: UserProfile,
     user_group_id: int = REQ(json_validator=check_int, path_only=True),
 ) -> HttpResponse:
-    check_delete_user_group(user_group_id, acting_user=user_profile)
+    # For deletion, the user group's recursive subgroups and the user group itself are locked.
+    with lock_subgroups_with_respect_to_supergroup(
+        [user_group_id], user_group_id, acting_user=user_profile
+    ) as context:
+        check_delete_user_group(context.supergroup, acting_user=user_profile)
     return json_success(request)
 
 
@@ -222,6 +227,7 @@ def notify_for_user_group_subscription_changes(
         do_send_messages(notifications)
 
 
+@transaction.atomic
 def add_members_to_group_backend(
     request: HttpRequest, user_profile: UserProfile, user_group_id: int, members: Sequence[int]
 ) -> HttpResponse:
@@ -251,6 +257,7 @@ def add_members_to_group_backend(
     return json_success(request)
 
 
+@transaction.atomic
 def remove_members_from_group_backend(
     request: HttpRequest, user_profile: UserProfile, user_group_id: int, members: Sequence[int]
 ) -> HttpResponse:
@@ -281,28 +288,33 @@ def add_subgroups_to_group_backend(
     if not subgroup_ids:
         return json_success(request)
 
-    subgroups = access_user_groups_as_potential_subgroups(subgroup_ids, user_profile)
-    user_group = access_user_group_by_id(user_group_id, user_profile, for_read=False)
-    existing_direct_subgroup_ids = user_group.direct_subgroups.all().values_list("id", flat=True)
-    for group in subgroups:
-        if group.id in existing_direct_subgroup_ids:
-            raise JsonableError(
-                _("User group {group_id} is already a subgroup of this group.").format(
-                    group_id=group.id
+    with lock_subgroups_with_respect_to_supergroup(
+        subgroup_ids, user_group_id, user_profile
+    ) as context:
+        existing_direct_subgroup_ids = context.supergroup.direct_subgroups.all().values_list(
+            "id", flat=True
+        )
+        for group in context.direct_subgroups:
+            if group.id in existing_direct_subgroup_ids:
+                raise JsonableError(
+                    _("User group {group_id} is already a subgroup of this group.").format(
+                        group_id=group.id
+                    )
                 )
+
+        recursive_subgroup_ids = {
+            recursive_subgroup.id for recursive_subgroup in context.recursive_subgroups
+        }
+        if user_group_id in recursive_subgroup_ids:
+            raise JsonableError(
+                _(
+                    "User group {user_group_id} is already a subgroup of one of the passed subgroups."
+                ).format(user_group_id=user_group_id)
             )
 
-    subgroup_ids = [group.id for group in subgroups]
-    if user_group_id in get_recursive_subgroups_for_groups(subgroup_ids).values_list(
-        "id", flat=True
-    ):
-        raise JsonableError(
-            _(
-                "User group {user_group_id} is already a subgroup of one of the passed subgroups."
-            ).format(user_group_id=user_group_id)
+        add_subgroups_to_user_group(
+            context.supergroup, context.direct_subgroups, acting_user=user_profile
         )
-
-    add_subgroups_to_user_group(user_group, subgroups, acting_user=user_profile)
     return json_success(request)
 
 
@@ -312,18 +324,27 @@ def remove_subgroups_from_group_backend(
     if not subgroup_ids:
         return json_success(request)
 
-    subgroups = access_user_groups_as_potential_subgroups(subgroup_ids, user_profile)
-    user_group = access_user_group_by_id(user_group_id, user_profile, for_read=False)
-    existing_direct_subgroup_ids = user_group.direct_subgroups.all().values_list("id", flat=True)
-    for group in subgroups:
-        if group.id not in existing_direct_subgroup_ids:
-            raise JsonableError(
-                _("User group {group_id} is not a subgroup of this group.").format(
-                    group_id=group.id
+    with lock_subgroups_with_respect_to_supergroup(
+        subgroup_ids, user_group_id, user_profile
+    ) as context:
+        # While the recursive subgroups in the context are not used, it is important that
+        # we acquire a lock for these rows while updating the subgroups to acquire the locks
+        # in a consistent order for subgroup membership changes.
+        existing_direct_subgroup_ids = context.supergroup.direct_subgroups.all().values_list(
+            "id", flat=True
+        )
+        for group in context.direct_subgroups:
+            if group.id not in existing_direct_subgroup_ids:
+                raise JsonableError(
+                    _("User group {group_id} is not a subgroup of this group.").format(
+                        group_id=group.id
+                    )
                 )
-            )
 
-    remove_subgroups_from_user_group(user_group, subgroups, acting_user=user_profile)
+        remove_subgroups_from_user_group(
+            context.supergroup, context.direct_subgroups, acting_user=user_profile
+        )
+
     return json_success(request)
 
 

--- a/zerver/views/user_groups.py
+++ b/zerver/views/user_groups.py
@@ -293,7 +293,9 @@ def add_subgroups_to_group_backend(
             )
 
     subgroup_ids = [group.id for group in subgroups]
-    if user_group_id in get_recursive_subgroups_for_groups(subgroup_ids):
+    if user_group_id in get_recursive_subgroups_for_groups(subgroup_ids).values_list(
+        "id", flat=True
+    ):
         raise JsonableError(
             _(
                 "User group {user_group_id} is already a subgroup of one of the passed subgroups."

--- a/zerver/views/user_groups.py
+++ b/zerver/views/user_groups.py
@@ -104,7 +104,7 @@ def edit_user_group(
     if name is None and description is None and can_mention_group_id is None:
         raise JsonableError(_("No new data supplied"))
 
-    user_group = access_user_group_by_id(user_group_id, user_profile)
+    user_group = access_user_group_by_id(user_group_id, user_profile, for_read=False)
 
     if name is not None and name != user_group.name:
         do_update_user_group_name(user_group, name, acting_user=user_profile)
@@ -228,7 +228,7 @@ def add_members_to_group_backend(
     if not members:
         return json_success(request)
 
-    user_group = access_user_group_by_id(user_group_id, user_profile)
+    user_group = access_user_group_by_id(user_group_id, user_profile, for_read=False)
     member_users = user_ids_to_users(members, user_profile.realm)
     existing_member_ids = set(get_direct_memberships_of_users(user_group, member_users))
 
@@ -258,7 +258,7 @@ def remove_members_from_group_backend(
         return json_success(request)
 
     user_profiles = user_ids_to_users(members, user_profile.realm)
-    user_group = access_user_group_by_id(user_group_id, user_profile)
+    user_group = access_user_group_by_id(user_group_id, user_profile, for_read=False)
     group_member_ids = get_user_group_direct_member_ids(user_group)
     for member in members:
         if member not in group_member_ids:
@@ -282,7 +282,7 @@ def add_subgroups_to_group_backend(
         return json_success(request)
 
     subgroups = access_user_groups_as_potential_subgroups(subgroup_ids, user_profile)
-    user_group = access_user_group_by_id(user_group_id, user_profile)
+    user_group = access_user_group_by_id(user_group_id, user_profile, for_read=False)
     existing_direct_subgroup_ids = user_group.direct_subgroups.all().values_list("id", flat=True)
     for group in subgroups:
         if group.id in existing_direct_subgroup_ids:
@@ -311,7 +311,7 @@ def remove_subgroups_from_group_backend(
         return json_success(request)
 
     subgroups = access_user_groups_as_potential_subgroups(subgroup_ids, user_profile)
-    user_group = access_user_group_by_id(user_group_id, user_profile)
+    user_group = access_user_group_by_id(user_group_id, user_profile, for_read=False)
     existing_direct_subgroup_ids = user_group.direct_subgroups.all().values_list("id", flat=True)
     for group in subgroups:
         if group.id not in existing_direct_subgroup_ids:

--- a/zproject/dev_urls.py
+++ b/zproject/dev_urls.py
@@ -10,6 +10,7 @@ from django.urls import path
 from django.views.generic import TemplateView
 from django.views.static import serve
 
+from zerver.lib.rest import rest_path
 from zerver.views.auth import config_error, login_page
 from zerver.views.development.cache import remove_caches
 from zerver.views.development.camo import handle_camo_url
@@ -31,6 +32,7 @@ from zerver.views.development.registration import (
     register_development_realm,
     register_development_user,
 )
+from zerver.views.development.user_groups import dev_update_subgroups
 
 # These URLs are available only in the development environment
 
@@ -97,6 +99,14 @@ urls = [
     # Redirect camo URLs for development
     path("external_content/<digest>/<received_url>", handle_camo_url),
 ]
+
+testing_urls = [
+    rest_path(
+        "testing/user_groups/<int:user_group_id>/subgroups",
+        POST=(dev_update_subgroups, {"intentionally_undocumented"}),
+    ),
+]
+urls += testing_urls
 
 v1_api_mobile_patterns = [
     # This is for the signing in through the devAuthBackEnd on mobile apps.


### PR DESCRIPTION
<!-- Describe your pull request here.-->
This demonstrates what happens when the openapi validator is not guarded by a thread lock.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
